### PR TITLE
Add missing codeFrameColumns import

### DIFF
--- a/switch-expr.macro.js
+++ b/switch-expr.macro.js
@@ -1,4 +1,5 @@
 const { createMacro, MacroError } = require('babel-plugin-macros');
+const { codeFrameColumns } = require('@babel/code-frame');
 const pkgName = 'switch-expr.macro';
 const debug = require('debug')(pkgName);
 


### PR DESCRIPTION
Just an oversight I assume. It's called in here but instead of nice error we get `codeFrameColumns is not defined` :)

https://github.com/ts-delight/switch-expr.macro/blob/8c4b62f8bfc9373f2f736f59e3f3686be27beab6/switch-expr.macro.js#L25-L26

PS: Looks like the same problem is in some other macros, eg. debug